### PR TITLE
Update facter usage

### DIFF
--- a/bench
+++ b/bench
@@ -391,13 +391,14 @@ class DevBench
   def about
     begin
       require 'facter'
+      raise LoadError if Gem::Version.new(Facter.version) < Gem::Version.new("4.0")
     rescue LoadError
       puts "Installing facter to gather system info, please re-run"
       `gem install facter`
       exit
     end
 
-    Facter::Util::Config.external_facts_dirs = []
+    Facter.reset
     facts = Facter.to_hash
 
     cores = Etc.nprocessors


### PR DESCRIPTION
`Facter.reset` (https://github.com/puppetlabs/facter-ng/blob/65d167eac93f47dde42ac0476c4f2f676fb07362/lib/facter.rb#L126-L137) clears `Facter::Options[:external_dir]` which seems to be the 4.x equivalent of `Facter::Util::Config.external_facts_dirs`.

This commit also makes sure that version 4.0 or higher is installed.