### PR TITLE
Update miniracer version to 0.3.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,7 +124,7 @@ gem 'mini_scheduler'
 gem 'tilt', require: false
 
 gem 'execjs', require: false
-gem 'mini_racer'
+gem 'mini_racer', '0.3.1'
 
 # TODO: determine why highline is being held back and upgrade to latest
 gem 'highline', '~> 1.7.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jwt (2.2.1)
     kgio (2.11.3)
-    libv8 (7.3.492.27.1)
+    libv8 (8.4.255.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -187,8 +187,8 @@ GEM
     method_source (0.9.2)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    mini_racer (0.2.9)
-      libv8 (>= 6.9.411)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     mini_scheduler (0.12.2)
       sidekiq
     mini_sql (0.2.4)
@@ -477,7 +477,7 @@ DEPENDENCIES
   memory_profiler
   message_bus
   mini_mime
-  mini_racer
+  mini_racer (= 0.3.1)
   mini_scheduler
   mini_sql
   mini_suffix
@@ -548,4 +548,4 @@ DEPENDENCIES
   yaml-lint
 
 BUNDLED WITH
-   2.1.1
+   2.1.4


### PR DESCRIPTION
This fixes API incompatibilities for older versions of libv8 that have
been fixed in a new version of miniracer.